### PR TITLE
Fix status bar icons on gradient screens

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,6 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class AppTheme {
+  static const SystemUiOverlayStyle gradientSystemOverlayStyle =
+      SystemUiOverlayStyle(
+        statusBarIconBrightness: Brightness.light,
+        statusBarBrightness: Brightness.dark,
+      );
+
   static ThemeData getThemeData(
     ColorScheme colorScheme,
     Brightness brightness,

--- a/lib/presentation/screens/dashboard/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard/dashboard_screen.dart
@@ -303,10 +303,7 @@ class _DashboardScreenState extends State<DashboardScreen>
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
-          systemOverlayStyle: const SystemUiOverlayStyle(
-            statusBarIconBrightness: Brightness.light,
-            statusBarBrightness: Brightness.dark,
-          ),
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
         ),
         body: BlocBuilder<UpcomingMaintenanceCubit, UpcomingMaintenanceState>(
           builder: (context, upcomingState) {

--- a/lib/presentation/screens/maintenance/add_edit_maintenance_plan_item_screen.dart
+++ b/lib/presentation/screens/maintenance/add_edit_maintenance_plan_item_screen.dart
@@ -345,6 +345,7 @@ class _AddEditMaintenancePlanItemScreenState
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
           leading: IconButton(
             icon: Icon(Icons.arrow_back_ios_new),
             tooltip: AppLocalizations.of(context)!.back,

--- a/lib/presentation/screens/maintenance/log_maintenance_screen.dart
+++ b/lib/presentation/screens/maintenance/log_maintenance_screen.dart
@@ -579,6 +579,7 @@ class _LogMaintenanceScreenState extends State<LogMaintenanceScreen> {
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
           leading: IconButton(
             icon: Icon(Icons.arrow_back_ios_new),
             tooltip: AppLocalizations.of(context)!.back,

--- a/lib/presentation/screens/settings/privacy_screen.dart
+++ b/lib/presentation/screens/settings/privacy_screen.dart
@@ -19,6 +19,7 @@ class PrivacyScreen extends StatelessWidget {
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
           leading: IconButton(
             icon: Icon(Icons.arrow_back_ios_new),
             tooltip: AppLocalizations.of(context)!.back,

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -630,6 +630,7 @@ class _SettingsScreenState extends State<SettingsScreen>
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
         ),
         body: ListView(
           padding: const EdgeInsets.only(bottom: 20),

--- a/lib/presentation/screens/vehicle/add_edit_vehicle_screen.dart
+++ b/lib/presentation/screens/vehicle/add_edit_vehicle_screen.dart
@@ -379,6 +379,7 @@ class _AddEditVehicleScreenState extends State<AddEditVehicleScreen> {
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
           leading: IconButton(
             icon: Icon(Icons.arrow_back_ios_new),
             tooltip: AppLocalizations.of(context)!.back,

--- a/lib/presentation/screens/vehicle/select_vehicle_screen.dart
+++ b/lib/presentation/screens/vehicle/select_vehicle_screen.dart
@@ -65,6 +65,7 @@ class SelectVehicleScreen extends StatelessWidget {
             context,
           ).colorScheme.inverseSurface.withValues(alpha: 0.1),
           elevation: 0,
+          systemOverlayStyle: AppTheme.gradientSystemOverlayStyle,
         ),
         body: SafeArea(
           top: false,

--- a/test/presentation/screens/form_submission_test.dart
+++ b/test/presentation/screens/form_submission_test.dart
@@ -144,15 +144,25 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('editing forms stay above the system navigation bar', (
-    tester,
-  ) async {
+  testWidgets('editing forms respect system bars', (tester) async {
     tester.view.physicalSize = const Size(360, 800);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     const systemPadding = EdgeInsets.only(bottom: 48);
     Future<void> expectFormAboveSystemNavigation(Type screenType) async {
+      final appBar = tester.widget<AppBar>(
+        find.descendant(
+          of: find.byType(screenType),
+          matching: find.byType(AppBar),
+        ),
+      );
+      expect(
+        appBar.systemOverlayStyle?.statusBarIconBrightness,
+        Brightness.light,
+      );
+      expect(appBar.systemOverlayStyle?.statusBarBrightness, Brightness.dark);
+
       final formScrollView = find.descendant(
         of: find.byType(screenType),
         matching: find.byType(SingleChildScrollView),

--- a/test/presentation/screens/settings/status_bar_theme_test.dart
+++ b/test/presentation/screens/settings/status_bar_theme_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:carvita/application/ports/notification_permission_port.dart';
+import 'package:carvita/application/ports/platform_ports.dart';
+import 'package:carvita/application/use_cases/reconcile_notification_permission.dart';
+import 'package:carvita/application/use_cases/vehicle_use_cases.dart';
+import 'package:carvita/core/services/backup_service.dart';
+import 'package:carvita/core/services/preferences_service.dart';
+import 'package:carvita/core/theme/app_theme.dart';
+import 'package:carvita/data/repositories/vehicle_repository.dart';
+import 'package:carvita/i18n/generated/app_localizations.dart';
+import 'package:carvita/presentation/manager/locale_provider.dart';
+import 'package:carvita/presentation/manager/theme_provider.dart';
+import 'package:carvita/presentation/manager/vehicle_list/vehicle_cubit.dart';
+import 'package:carvita/presentation/screens/settings/privacy_screen.dart';
+import 'package:carvita/presentation/screens/settings/settings_screen.dart';
+import 'package:carvita/presentation/screens/vehicle/select_vehicle_screen.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('settings gradient uses light status bar icons', (tester) async {
+    await tester.pumpWidget(_settingsApp());
+    await tester.pumpAndSettle();
+
+    _expectLightStatusBar(tester);
+  });
+
+  testWidgets('settings-related gradient routes use light status bar icons', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_testApp(child: const PrivacyScreen()));
+    await tester.pumpAndSettle();
+    _expectLightStatusBar(tester);
+
+    await tester.pumpWidget(
+      _testApp(child: const SelectVehicleScreen(vehicles: [])),
+    );
+    await tester.pumpAndSettle();
+    _expectLightStatusBar(tester);
+  });
+}
+
+void _expectLightStatusBar(WidgetTester tester) {
+  final appBar = tester.widget<AppBar>(find.byType(AppBar));
+  expect(appBar.systemOverlayStyle?.statusBarIconBrightness, Brightness.light);
+  expect(appBar.systemOverlayStyle?.statusBarBrightness, Brightness.dark);
+}
+
+Widget _settingsApp() {
+  final preferences = PreferencesService();
+  final notifications = _Notifications();
+  final vehicleUseCases = VehicleUseCases(VehicleRepository(), preferences);
+
+  return MultiProvider(
+    providers: [
+      Provider<PreferencesService>.value(value: preferences),
+      Provider<VehicleUseCases>.value(value: vehicleUseCases),
+      Provider<NotificationPermissionGateway>.value(value: notifications),
+      Provider<ReconcileNotificationPermission>.value(
+        value: ReconcileNotificationPermission(preferences, notifications),
+      ),
+      Provider<BackupGateway>.value(value: _BackupGateway()),
+      Provider<BackupFilePickerPort>.value(value: _FilePicker()),
+      Provider<FileSharePort>.value(value: _SharePort()),
+      Provider<AppPackageInfoPort>.value(value: _PackageInfo()),
+      Provider<ExternalUrlPort>.value(value: _ExternalUrl()),
+      Provider<AppExitPort>.value(value: _AppExit()),
+      ChangeNotifierProvider<LocaleProvider>(
+        create: (_) => LocaleProvider(preferences),
+      ),
+      ChangeNotifierProvider<ThemeProvider>(
+        create: (_) => ThemeProvider(preferences),
+      ),
+      BlocProvider<VehicleCubit>(create: (_) => VehicleCubit(vehicleUseCases)),
+    ],
+    child: _testApp(child: const SettingsScreen()),
+  );
+}
+
+Widget _testApp({required Widget child}) {
+  const brightness = Brightness.light;
+  final colorScheme = ColorScheme.fromSeed(
+    seedColor: Colors.blue,
+    brightness: brightness,
+  );
+
+  return MaterialApp(
+    locale: const Locale('en'),
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    theme: AppTheme.getThemeData(colorScheme, brightness),
+    home: child,
+  );
+}
+
+final class _BackupGateway implements BackupGateway {
+  @override
+  Future<String> createExportSnapshot({
+    String applicationVersion = 'unknown',
+  }) async {
+    return 'test.cvbackup';
+  }
+
+  @override
+  Future<void> deleteExportSnapshot(String snapshotPath) async {}
+
+  @override
+  Future<void> restoreDatabase(String selectedPath) async {}
+}
+
+final class _FilePicker implements BackupFilePickerPort {
+  @override
+  Future<String?> pickBackupFile() async => null;
+}
+
+final class _SharePort implements FileSharePort {
+  @override
+  Future<ShareFileOutcome> shareFile(String path) async {
+    return ShareFileOutcome.success;
+  }
+}
+
+final class _PackageInfo implements AppPackageInfoPort {
+  @override
+  Future<AppPackageInfo> loadPackageInfo() async {
+    return const AppPackageInfo(version: 'test');
+  }
+}
+
+final class _ExternalUrl implements ExternalUrlPort {
+  @override
+  Future<void> openExternalUrl(Uri uri) async {}
+}
+
+final class _AppExit implements AppExitPort {
+  @override
+  Future<void> exitApplication() async {}
+}
+
+final class _Notifications implements NotificationPermissionGateway {
+  @override
+  Future<void> cancelAllNotifications() async {}
+
+  @override
+  Future<bool> checkPermissions() async => true;
+
+  @override
+  Future<bool> requestPermissions() async => true;
+}


### PR DESCRIPTION
## Summary

- Centralize the status bar overlay style for gradient app bars.
- Apply light status bar icons across dashboard, settings, privacy, vehicle, and maintenance screens.
- Add widget coverage to verify status bar brightness on gradient routes.

## Testing

- Added widget tests for settings-related gradient routes and form screens.